### PR TITLE
Fix Dockerfile and add README documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,4 @@ RUN pip install -r requirements.txt
 COPY . /app
 
 EXPOSE 8080
-ENTRYPOINT [ "python" ]
-
-CMD [ "app.py" ]
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# Simple FastAPI "Hello World" Application
+
+This project is a very simple web application built with Python and the [FastAPI](https://fastapi.tiangolo.com/) framework. It provides a single API endpoint that returns a "Hello World" message.
+
+The application is containerized using Docker.
+
+## API Endpoint
+
+### `GET /`
+
+Returns a JSON response with a "Hello World" message.
+
+**Example Response:**
+
+```json
+{
+  "message": "Hello World"
+}
+```
+
+## How to Run
+
+This application is designed to be run as a Docker container.
+
+### Prerequisites
+
+*   [Docker](https://docs.docker.com/get-docker/) installed on your machine.
+
+### Steps
+
+1.  **Clone the repository:**
+
+    ```bash
+    git clone <repository-url>
+    cd <repository-directory>
+    ```
+
+2.  **Build the Docker image:**
+
+    From the root of the project directory, run the following command:
+
+    ```bash
+    docker build -t fastapi-hello-world .
+    ```
+
+3.  **Run the Docker container:**
+
+    ```bash
+    docker run -p 8080:8080 fastapi-hello-world
+    ```
+
+4.  **Access the application:**
+
+    Open your web browser or use a tool like `curl` to access the application at:
+
+    [http://localhost:8080](http://localhost:8080)
+
+    You should see the following response:
+
+    ```json
+    {"message":"Hello World"}
+    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 fastapi
+uvicorn[standard]


### PR DESCRIPTION
This commit addresses two main points:

1.  **Fixes the Dockerfile:** The original Dockerfile was not correctly configured to run the FastAPI application. It lacked the `uvicorn` server dependency and the correct command to start it. This has been fixed by:
    *   Adding `uvicorn[standard]` to `requirements.txt`.
    *   Updating the `CMD` in the `Dockerfile` to launch the application with `uvicorn`.

2.  **Adds Documentation:** A `README.md` file has been created to provide clear instructions on what the application is and how to build and run it using Docker.